### PR TITLE
Add Local Participant Id option when Exporting Study as CSV files

### DIFF
--- a/data_warehouse_client/study_summary.py
+++ b/data_warehouse_client/study_summary.py
@@ -129,7 +129,7 @@ def print_all_instances_in_a_study_to_csv_files(dw, study):
 
 
 def print_instances_in_a_study_to_csv_files(dw, study, report_dir, select_participants=False, participants=[],
-                                            filename_prefix=''):
+                                            local_participant_id=True, filename_prefix=''):
     """
     Print instances in a study to a set of csvs - one per measurement group,
     but only for those participants in the participants list
@@ -138,21 +138,31 @@ def print_instances_in_a_study_to_csv_files(dw, study, report_dir, select_partic
     :param report_dir: the directory in which the profiles will be written
     :param select_participants: select a subset of participants to be included in the profile
     :param participants: list of participants to be included in the profile if select_participants is true
+    :param local_participant_id: include the local participant id if this boolean is True
     :param filename_prefix: optional string to add to front of filename
     """
     timestamp = datetime.datetime.now()  # use the current date and time if none is specified
     time_fname_str = timestamp.strftime('%Y-%m-%dh%Hm%Ms%S')
+    participant_index = 3  # the participant_id is in position 3 of the list
     measurement_groups = dw.get_all_measurement_groups(study)
     for [mg_id, mg_name] in measurement_groups:
         (header, all_instances) = dw.get_measurement_group_instances(study, mg_id, [])
         if select_participants:  # select participants
-            participant_index = 3   # the participant_id is in position 3 of the list
             instances = list(filter(lambda instance: instance[participant_index] in participants, all_instances))
         else:
             instances = all_instances
         fname = mk_csv_report_file_name(report_dir, filename_prefix +
                                         "study-instances-" + mg_name + "-", time_fname_str)
-        csv_io.export_measurement_groups_as_csv(header, instances, fname)
+        if local_participant_id:
+            instances_with_local_participant_id = []
+            extended_header = ['Local Participant'] + header
+            for instance in instances:  # add the local participant id to the start of each row
+                participant_id = instance[participant_index]  # get unique participant id
+                (success, part) = dw.get_participant_by_id(study, participant_id)  # get local participant id
+                instances_with_local_participant_id = instances_with_local_participant_id + [[part] + instance]
+                csv_io.export_measurement_groups_as_csv(extended_header, instances_with_local_participant_id, fname)
+        else:  # don't include local id
+            csv_io.export_measurement_groups_as_csv(header, instances, fname)
 
 
 def print_all_instances_in_a_study_with_local_participant_id_to_csv_files(dw, study):


### PR DESCRIPTION
print_instances_in_a_study_to_csv_files ammended to add option to include the local participant id when exporting a study as a set of csv files (one per measurement group).
The option is controlled by the parameter local_participant_id which defaults to True (include the local participant id)